### PR TITLE
Bugfix for compatibility with base < 4.11.

### DIFF
--- a/Data/Set/Monad.hs
+++ b/Data/Set/Monad.hs
@@ -159,6 +159,7 @@ import qualified Control.Applicative  as A
 import qualified Data.Foldable        as Foldable
 
 import Data.Foldable (Foldable)
+import Data.Semigroup
 import Control.Arrow
 import Control.Monad
 import Control.DeepSeq


### PR DESCRIPTION
This patch fixes an incompatibility between set-monad and base < 4.11.

Ghc 8.2 and earlier uses base < 4.11, and is still widely used (e.g., it is the default Haskell platform you get on Ubuntu). Rather than forcing users to upgrade ghc, it makes more sense in this case to support 4.9 <= base < 4.11, as there is no downside.
 