### PR TITLE
Make appropriate fields strict

### DIFF
--- a/Data/Set/Monad.hs
+++ b/Data/Set/Monad.hs
@@ -169,11 +169,11 @@ import Control.Monad
 import Control.DeepSeq
 
 data Set a where
-  Prim   :: (Ord a) => S.Set a -> Set a
+  Prim   :: (Ord a) => !(S.Set a) -> Set a
   Return :: a -> Set a
-  Bind   :: Set a -> (a -> Set b) -> Set b
+  Bind   :: !(Set a) -> (a -> Set b) -> Set b
   Zero   :: Set a
-  Plus   :: Set a -> Set a -> Set a
+  Plus   :: !(Set a) -> !(Set a) -> Set a
 
 run :: (Ord a) => Set a -> S.Set a
 run (Prim s)                        = s


### PR DESCRIPTION
There's no apparent gain from making primitive or `Set` fields lazy, and doing so (especially for `Prim`) risks creating inefficient chains of thunks. Make those fields strict instead.